### PR TITLE
Disable registrations

### DIFF
--- a/app/views/decidim/devise/shared/_links.html.erb
+++ b/app/views/decidim/devise/shared/_links.html.erb
@@ -4,6 +4,12 @@
   </p>
 <% end -%>
 
+<%- if devise_mapping.registerable? && controller_name != "registrations" %>
+  <p class="text-center sign-up-link">
+    <%= link_to t("devise.shared.links.sign_up"), new_registration_path(resource_name) %>
+  </p>
+<% end -%>
+
 <%- if devise_mapping.recoverable? && controller_name != "passwords" %>
   <p class="text-center">
     <%= link_to t("devise.shared.links.forgot_your_password"), new_password_path(resource_name) %>

--- a/app/views/decidim/devise/shared/_links.html.erb
+++ b/app/views/decidim/devise/shared/_links.html.erb
@@ -1,0 +1,23 @@
+<%- if controller_name != "sessions" %>
+  <p class="text-center">
+    <%= link_to t("devise.shared.links.sign_in"), new_session_path(resource_name) %>
+  </p>
+<% end -%>
+
+<%- if devise_mapping.recoverable? && controller_name != "passwords" %>
+  <p class="text-center">
+    <%= link_to t("devise.shared.links.forgot_your_password"), new_password_path(resource_name) %>
+  </p>
+<% end -%>
+
+<%- if devise_mapping.confirmable? && controller_name != "confirmations" %>
+  <p class="text-center">
+    <%= link_to t("devise.shared.links.didn_t_receive_confirmation_instructions"), new_confirmation_path(resource_name) %>
+  </p>
+<% end -%>
+
+<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != "unlocks" %>
+  <p class="text-center">
+    <%= link_to t("devise.shared.links.didn_t_receive_unlock_instructions"), new_unlock_path(resource_name) %>
+  </p>
+<% end -%>


### PR DESCRIPTION
This adds the class for user registration, so we can hide it only for a Tenant and disable this links (using the good ol' display: none;). 