### PR TITLE
Relax password length requirement

### DIFF
--- a/config/initializers/nobspw.rb
+++ b/config/initializers/nobspw.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+NOBSPW.configure do |config|
+  config.min_password_length = 8
+end


### PR DESCRIPTION
`nobspw` sets the default at 10 characters which could be too long for some users.