### PR TITLE
OmniAuth login with Decidim.Barcelona button and strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 /node_modules
 /yarn-error.log
 
+.rbenv-vars
 .byebug_history
 
 # Ignore public uploads

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "decidim", DECIDIM_VERSION
 gem "decidim-initiatives", DECIDIM_VERSION
 gem "decidim-consultations", DECIDIM_VERSION
 gem "decidim-conferences", DECIDIM_VERSION
+gem "omniauth-decidim", git: "https://github.com/decidim/omniauth-decidim"
 
 gem "puma", "~> 3"
 gem "uglifier"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,6 +211,14 @@ GIT
     decidim-verifications (0.19.0)
       decidim-core (= 0.19.0)
 
+GIT
+  remote: https://github.com/decidim/omniauth-decidim
+  revision: 2b7d087f1b581e06cc82b7716d09cc50e1d0e643
+  specs:
+    omniauth-decidim (0.1.0)
+      omniauth (~> 1.5)
+      omniauth-oauth2 (>= 1.4.0, < 2.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -831,6 +839,7 @@ DEPENDENCIES
   listen (~> 3.1.0)
   lograge
   newrelic_rpm
+  omniauth-decidim!
   passenger
   platform-api
   puma (~> 3)

--- a/app/assets/images/icon-barcelona.svg
+++ b/app/assets/images/icon-barcelona.svg
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   id="Negativo"
+   x="0px"
+   y="0px"
+   viewBox="0 0 146.8 183.5"
+   xml:space="preserve"
+   width="16"
+   height="20"><metadata
+   id="metadata69"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title>decidim-logo</dc:title></cc:Work></rdf:RDF></metadata><defs
+   id="defs67" />
+<style
+   type="text/css"
+   id="style2">
+	.st0{fill:#D9E7E5;}
+	.st1{fill:#ED6A5A;}
+	.st2{fill:#31536E;}
+	.st3{fill:#A0C3BF;}
+</style>
+<title
+   id="title4">decidim-logo</title>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<rect
+   ry="21.771185"
+   y="-1.8661016"
+   x="0"
+   height="183.5"
+   width="146.8"
+   id="rect22"
+   style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:325.09841919;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" /><path
+   class="st1"
+   d="m 93.718305,165.15 c 19.899835,-0.2 35.999695,-16.3 36.199695,-36.1 v -0.7 c -0.2,-19.9 -16.29986,-36 -36.199695,-36.2 v 0 -0.7 0 C 113.61814,91.25 129.71799,75.15 129.918,55.25 v -0.7 c -0.30001,-19.9 -16.29986,-36 -36.199695,-36.2 h -73.79938 v 73 0 0.7 0 73 z m -0.7,-73 v 0 -0.7 0 z"
+   id="path38"
+   style="fill:#ed6a5a;stroke-width:0.99999577" />
+<path
+   class="st2"
+   d="m 92.918305,92.15 c -19.899829,0.2 -35.999693,16.3 -36.199691,36.2 19.999831,-0.2 35.999691,-16.3 36.199691,-36.2 z"
+   id="path40"
+   style="fill:#31536e;stroke-width:0.99999577" />
+<path
+   class="st2"
+   d="m 56.818613,129.04999 c 0.199998,19.9 16.299862,35.9 36.199692,36.1 -0.3,-19.8 -16.29986,-35.9 -36.199692,-36.1 z"
+   id="path42"
+   style="fill:#31536e;stroke-width:0.99999577" />
+<path
+   class="st2"
+   d="m 56.118619,128.25 c -0.199998,-19.8 -16.299862,-35.9 -36.199694,-36.1 0.199998,19.9 16.299862,35.9 36.199694,36.1 z"
+   id="path44"
+   style="fill:#31536e;stroke-width:0.99999577" />
+<path
+   class="st2"
+   d="m 56.118619,129.04999 c -19.899832,0.2 -35.999696,16.3 -36.199694,36.1 19.899832,-0.2 35.999696,-16.2 36.199694,-36.1 z"
+   id="path46"
+   style="fill:#31536e;stroke-width:0.99999577" />
+<path
+   class="st2"
+   d="m 56.118619,54.55 c -0.199998,-19.9 -16.299862,-36 -36.199694,-36.2 0.199998,19.9 16.299862,36 36.199694,36.2 z"
+   id="path48"
+   style="fill:#31536e;stroke-width:0.99999577" />
+<path
+   class="st2"
+   d="m 56.118619,55.25 c -19.899832,0.2 -35.999696,16.3 -36.199694,36.2 19.899832,-0.2 35.999696,-16.3 36.199694,-36.2 z"
+   id="path50"
+   style="fill:#31536e;stroke-width:0.99999577" />
+<path
+   class="st2"
+   d="m 92.918305,18.35 c -19.899829,0.2 -35.999693,16.3 -36.099692,36.2 19.899832,-0.2 35.999692,-16.3 36.099692,-36.2 z"
+   id="path52"
+   style="fill:#31536e;stroke-width:0.99999577" />
+<path
+   class="st2"
+   d="m 56.818613,55.25 c 0.199998,19.9 16.299862,35.9 36.099692,36.2 -0.1,-19.9 -16.19986,-36 -36.099692,-36.2 z"
+   id="path54"
+   style="fill:#31536e;stroke-width:0.99999577" />
+<path
+   class="st3"
+   d="m 19.918925,165.15 c 0.199998,-19.9 16.299862,-36 36.199694,-36.1 v -0.7 c -19.899832,-0.3 -35.999696,-16.3 -36.199694,-36.2 z"
+   id="path56"
+   style="fill:#a0c3bf;stroke-width:0.99999577" />
+<path
+   class="st3"
+   d="m 129.818,128.25 c -19.89983,-0.2 -35.999705,-16.3 -36.199695,-36.2 h -0.7 c -0.2,19.9 -16.299859,36 -36.199691,36.2 v 0.7 c 19.899832,0.2 35.999691,16.3 36.199691,36.1 h 0.8 c 0.19999,-19.9 16.299865,-36 36.199695,-36.1 v -0.7 z"
+   id="path58"
+   style="fill:#a0c3bf;stroke-width:0.99999577" />
+<path
+   class="st3"
+   d="m 19.918925,91.45 c 0.199998,-19.9 16.299862,-36 36.199694,-36.2 v -0.7 C 36.218787,54.35 20.118923,38.25 19.918925,18.35 Z"
+   id="path60"
+   style="fill:#a0c3bf;stroke-width:0.99999577" />
+<path
+   class="st3"
+   d="M 129.818,54.55 C 110.01817,54.35 93.918295,38.25 93.718305,18.35 h -0.8 c -0.2,19.9 -16.299859,36 -36.099692,36.2 v 0.7 c 19.899832,0.2 35.999692,16.3 36.199692,36.1 h 0.7 c 0.19999,-19.9 16.299865,-36 36.199695,-36.2 v -0.6 z"
+   id="path62"
+   style="fill:#a0c3bf;stroke-width:0.99999577" />
+</svg>

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -11,6 +11,6 @@
  * It is generally better to create a new file per style scope.
  *
  *= require decidim
- *= require_tree .
+ *= require_tree ./custom
  *= require_self
  */

--- a/app/assets/stylesheets/custom/omniauth_buttons.scss
+++ b/app/assets/stylesheets/custom/omniauth_buttons.scss
@@ -1,0 +1,27 @@
+// Ajustements for Decidim (login with Barcelona) login button
+.button--social.button--decidim {
+  .button--social__icon {
+    padding-top: 0.7rem;
+    padding-bottom: 0.5rem;
+    svg {
+      width: auto;
+      height: 32px;
+    }
+  }
+}
+
+@media(max-width: 372px) {
+  .button--social.button--decidim {
+    padding: 0.5rem 1rem 0.5rem 3.7rem;
+    min-height: 3rem;
+    position: relative;
+    line-height: 1rem;
+
+    .button--social__icon {
+      position: absolute;
+      left:0;
+      top:0;
+      padding: 0.5em 0.5em;
+    }
+  }
+}

--- a/app/views/decidim/devise/shared/_omniauth_buttons.html.erb
+++ b/app/views/decidim/devise/shared/_omniauth_buttons.html.erb
@@ -1,0 +1,23 @@
+<% if Devise.mappings[:user].omniauthable? && any_social_provider_enabled? %>
+  <div class="row">
+    <div class="columns large-4 mediumlarge-6 medium-8 medium-centered">
+      <%- Decidim::User.omniauth_providers.each do |provider| %>
+        <% if social_provider_enabled? provider %>
+          <div class="social-register">
+            <%= link_to decidim.send("user_#{provider}_omniauth_authorize_path"), class: "button button--social button--#{normalize_provider_name(provider)}", method: :post do %>
+              <span class="button--social__icon">
+                <%= oauth_icon provider %>
+              </span>
+              <%= t("devise.shared.links.sign_in_with_provider", provider: normalize_provider_name(provider).titleize) %><%= ('.Barcelona' if provider.to_s == 'decidim') %>
+            <% end %>
+          </div>
+        <% end %>
+      <% end %>
+      <%- if current_organization.sign_in_enabled? %>
+        <span class="register__separator">
+          <span class="register__separator__text"><%= t(".or") %></span>
+        </span>
+      <%- end %>
+    </div>
+  </div>
+<% end %>

--- a/config/initializers/omniauth_decidim.rb
+++ b/config/initializers/omniauth_decidim.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+if Rails.application.secrets.dig(:omniauth, :decidim, :enabled)
+  Devise.setup do |config|
+    config.omniauth :decidim,
+                    Rails.application.secrets.dig(:omniauth, :decidim, :client_id),
+                    Rails.application.secrets.dig(:omniauth, :decidim, :client_secret),
+                    Rails.application.secrets.dig(:omniauth, :decidim, :site_url),
+                    scope: :public
+  end
+  Decidim::User.omniauth_providers << :decidim
+
+end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -32,6 +32,12 @@ default: &default
       enabled: false
       client_id: <%= ENV["OMNIAUTH_GOOGLE_CLIENT_ID"] %>
       client_secret: <%= ENV["OMNIAUTH_GOOGLE_CLIENT_SECRET"] %>
+    decidim:
+      enabled: true
+      client_id: <%= ENV["OMNIAUTH_DECIDIM_CLIENT_ID"] %>
+      client_secret: <%= ENV["OMNIAUTH_DECIDIM_CLIENT_SECRET"] %>
+      site_url: "https://www.decidim.barcelona"
+      icon_path: icon-barcelona.svg
   geocoder:
     here_app_id: <%= ENV["GEOCODER_LOOKUP_APP_ID"] %>
     here_app_code: <%= ENV["GEOCODER_LOOKUP_APP_CODE"] %>
@@ -42,7 +48,12 @@ development:
   omniauth:
     developer:
       enabled: true
-
+    decidim:
+      enabled: true
+      client_id: <%= ENV["OMNIAUTH_DECIDIM_CLIENT_ID"] %>
+      client_secret: <%= ENV["OMNIAUTH_DECIDIM_CLIENT_SECRET"] %>
+      site_url: "https://www.decidim.barcelona"
+      icon_path: icon-barcelona.svg
 test:
   <<: *default
   secret_key_base: 37d4a6caf41586fef44b7f2a744d70439803deb93efa2795552fa427c89bd3dc99c26e44a8dc8880819e7f00853b41bd77255ee8226f01ca32f69fc1ffc3c0cc


### PR DESCRIPTION
Adds the "login with Decidim.Barcelona".

**IMPORTANT**

Before merge, please create in https://www.decidim.barcelona id and secret keys for the organizations.
Then configure the ENV vars:
`OMNIAUTH_DECIDIM_CLIENT_ID`
`OMNIAUTH_DECIDIM_CLIENT_SECRET`


Fixes #56 
![imatge](https://user-images.githubusercontent.com/1401520/71410323-19763e80-2645-11ea-9237-5edbb5b67dfb.png)
