### PR TITLE
Add Italian locale

### DIFF
--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -7,7 +7,7 @@ Decidim.configure do |config|
 
   # Change these lines to set your preferred locales
   config.default_locale = :ca
-  config.available_locales = [:ca, :es, :en, :fr]
+  config.available_locales = [:ca, :es, :en, :fr, :it]
 
   # Geocoder configuration
   config.geocoder = {


### PR DESCRIPTION
In order to be able to support the Italian language in some organizations it is required to add it to the list of I18n.available_locales at boot time.