### PR TITLE
Keep geocoder in version 1.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,9 @@ gem "uglifier"
 gem "wicked_pdf"
 gem "wkhtmltopdf-binary"
 
+# geocoder can not be upgraded to 1.6 until the Here maps api key is changed for the new one
+gem "geocoder", "~> 1.5.2"
+
 gem 'rails-observers'
 
 gem "faker", "~> 1.8.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -428,7 +428,7 @@ GEM
       activesupport (>= 4.1, < 6.0)
       railties (>= 4.1, < 6.0)
       tzinfo (~> 1.2, >= 1.2.2)
-    geocoder (1.6.2)
+    geocoder (1.5.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     graphiql-rails (1.4.11)
@@ -837,6 +837,7 @@ DEPENDENCIES
   decidim-term_customizer!
   faker (~> 1.8.4)
   fog-aws
+  geocoder (~> 1.5.2)
   letter_opener_web (~> 1.3.0)
   listen (~> 3.1.0)
   lograge


### PR DESCRIPTION
Keep geocoder in version 1.5 to stay with the legacy HERE-maps api credentials