### PR TITLE
Use Puma server instead of Passenger

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,6 @@ group :development do
 end
 
 group :production do
-  gem 'passenger'
   gem 'fog-aws'
   gem 'dalli'
   gem 'sendgrid-ruby'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -586,9 +586,6 @@ GEM
     parallel (1.19.1)
     parser (2.7.1.2)
       ast (~> 2.4.0)
-    passenger (6.0.4)
-      rack
-      rake (>= 0.8.1)
     pg (1.1.4)
     pg_search (2.3.2)
       activerecord (>= 5.2)
@@ -852,7 +849,6 @@ DEPENDENCIES
   listen (~> 3.1.0)
   lograge
   newrelic_rpm
-  passenger
   platform-api
   puma
   rails (< 6)

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-web: bundle exec passenger start -p ${PORT:-3000} --max-pool-size ${WEB_CONCURRENCY:-5}
+web: bundle exec puma -C config/puma.rb
 worker: bundle exec sidekiq -e ${RACK_ENV:-development} -C config/sidekiq.yml
 release: bundle exec rake db:migrate

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: bundle exec passenger start -p ${PORT:-3000} --max-pool-size ${WEB_CONCURRENCY:-5}
 worker: bundle exec sidekiq -e ${RACK_ENV:-development} -C config/sidekiq.yml
+release: bundle exec rake db:migrate

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -13,7 +13,7 @@ port        ENV.fetch("PORT") { 3000 }
 
 # Specifies the `environment` that Puma will run in.
 #
-environment ENV.fetch("RAILS_ENV") { "development" }
+environment ENV.fetch("RAILS_ENV") { "production" }
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked webserver processes. If using threads and workers together
@@ -21,7 +21,7 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+workers ENV.fetch("WEB_CONCURRENCY") { 2 }
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code
@@ -30,15 +30,15 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # you need to make sure to reconnect any threads in the `on_worker_boot`
 # block.
 #
-# preload_app!
+preload_app!
 
 # If you are preloading your application and using Active Record, it's
 # recommended that you close any connections to the database before workers
 # are forked to prevent connection leakage.
 #
-# before_fork do
-#   ActiveRecord::Base.connection_pool.disconnect! if defined?(ActiveRecord)
-# end
+before_fork do
+  ActiveRecord::Base.connection_pool.disconnect! if defined?(ActiveRecord)
+end
 
 # The code in the `on_worker_boot` will be called if you are using
 # clustered mode by specifying a number of `workers`. After each worker
@@ -47,10 +47,9 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # or connections that may have been created at application boot, as Ruby
 # cannot share connections between processes.
 #
-# on_worker_boot do
-#   ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
-# end
-#
+on_worker_boot do
+  ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
+end
 
 # Allow puma to be restarted by `rails restart` command.
-plugin :tmp_restart
+# plugin :tmp_restart

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,11 +2,11 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
-# be faster and is potentially less error prone than running all of your
-# migrations from scratch. Old migrations may fail to apply correctly if those
-# migrations use external dependencies or application code.
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
 #
 # It's strongly recommended that you check this file into your version control system.
 


### PR DESCRIPTION
Right now Passenger is failing to instantiate servers when adding new dynos. This PR removes Passenger and uses Puma as this is the oficial and tested server for Decidim.


Passenger's crash backtrace:

```
2020-05-29T14:13:42.886852+00:00 app[web.2]: Stopping web server...bundler: failed to load command: passenger (/app/vendor/bundle/ruby/2.6.0/bin/passenger)
2020-05-29T14:13:42.886974+00:00 app[web.2]: PhusionPassenger::DaemonController::StopError: nginx: [error] open() "/app/passenger.44459.pid" failed (2: No such file or directory)
2020-05-29T14:13:42.886976+00:00 app[web.2]: /app/vendor/bundle/ruby/2.6.0/gems/passenger-6.0.4/src/ruby_supportlib/phusion_passenger/vendor/daemon_controller.rb:448:in `rescue in kill_daemon'
2020-05-29T14:13:42.886976+00:00 app[web.2]: /app/vendor/bundle/ruby/2.6.0/gems/passenger-6.0.4/src/ruby_supportlib/phusion_passenger/vendor/daemon_controller.rb:445:in `kill_daemon'
2020-05-29T14:13:42.886977+00:00 app[web.2]: /app/vendor/bundle/ruby/2.6.0/gems/passenger-6.0.4/src/ruby_supportlib/phusion_passenger/vendor/daemon_controller.rb:304:in `block (2 levels) in stop'
2020-05-29T14:13:42.886978+00:00 app[web.2]: /app/vendor/ruby-2.6.3/lib/ruby/2.6.0/timeout.rb:93:in `block in timeout'
2020-05-29T14:13:42.886978+00:00 app[web.2]: /app/vendor/ruby-2.6.3/lib/ruby/2.6.0/timeout.rb:103:in `timeout'
2020-05-29T14:13:42.886978+00:00 app[web.2]: /app/vendor/bundle/ruby/2.6.0/gems/passenger-6.0.4/src/ruby_supportlib/phusion_passenger/vendor/daemon_controller.rb:303:in `block in stop'
2020-05-29T14:13:42.886979+00:00 app[web.2]: /app/vendor/bundle/ruby/2.6.0/gems/passenger-6.0.4/src/ruby_supportlib/phusion_passenger/vendor/daemon_controller/lock_file.rb:68:in `block in exclusive_lock'
2020-05-29T14:13:42.886980+00:00 app[web.2]: /app/vendor/bundle/ruby/2.6.0/gems/passenger-6.0.4/src/ruby_supportlib/phusion_passenger/vendor/daemon_controller/lock_file.rb:63:in `open'
2020-05-29T14:13:42.886980+00:00 app[web.2]: /app/vendor/bundle/ruby/2.6.0/gems/passenger-6.0.4/src/ruby_supportlib/phusion_passenger/vendor/daemon_controller/lock_file.rb:63:in `exclusive_lock'
2020-05-29T14:13:42.886981+00:00 app[web.2]: /app/vendor/bundle/ruby/2.6.0/gems/passenger-6.0.4/src/ruby_supportlib/phusion_passenger/vendor/daemon_controller.rb:301:in `stop'
2020-05-29T14:13:42.886981+00:00 app[web.2]: /app/vendor/bundle/ruby/2.6.0/gems/passenger-6.0.4/src/ruby_supportlib/phusion_passenger/standalone/start_command.rb:531:in `block in trapsafe_shutdown_and_cleanup'
2020-05-29T14:13:42.886982+00:00 app[web.2]: /app/vendor/bundle/ruby/2.6.0/gems/passenger-6.0.4/src/ruby_supportlib/phusion_passenger/standalone/start_command.rb:528:in `synchronize'
2020-05-29T14:13:42.886982+00:00 app[web.2]: /app/vendor/bundle/ruby/2.6.0/gems/passenger-6.0.4/src/ruby_supportlib/phusion_passenger/standalone/start_command.rb:528:in `trapsafe_shutdown_and_cleanup'
2020-05-29T14:13:42.886983+00:00 app[web.2]: /app/vendor/bundle/ruby/2.6.0/gems/passenger-6.0.4/src/ruby_supportlib/phusion_passenger/standalone/start_command.rb:76:in `rescue in run'
2020-05-29T14:13:42.886983+00:00 app[web.2]: /app/vendor/bundle/ruby/2.6.0/gems/passenger-6.0.4/src/ruby_supportlib/phusion_passenger/standalone/start_command.rb:72:in `run'
2020-05-29T14:13:42.886984+00:00 app[web.2]: /app/vendor/bundle/ruby/2.6.0/gems/passenger-6.0.4/src/ruby_supportlib/phusion_passenger/standalone/main.rb:51:in `run!'
2020-05-29T14:13:42.886984+00:00 app[web.2]: /app/vendor/bundle/ruby/2.6.0/gems/passenger-6.0.4/bin/passenger:45:in `<top (required)>'
2020-05-29T14:13:42.886985+00:00 app[web.2]: /app/vendor/bundle/ruby/2.6.0/bin/passenger:23:in `load'
2020-05-29T14:13:42.886985+00:00 app[web.2]: /app/vendor/bundle/ruby/2.6.0/bin/passenger
```