### PR TITLE
Add 9 groups to Decidim's Direct-Verification module config

### DIFF
--- a/config/initializers/decidim_verifications.rb
+++ b/config/initializers/decidim_verifications.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# We are using the same DirectVerifications engine without the admin part to
+# create a 9 different custom verifications
+
+Decidim::Verifications.register_workflow(:direct_verifications_grup1) do |workflow|
+  workflow.engine = Decidim::DirectVerifications::Verification::Engine
+end
+Decidim::Verifications.register_workflow(:direct_verifications_grup2) do |workflow|
+  workflow.engine = Decidim::DirectVerifications::Verification::Engine
+end
+Decidim::Verifications.register_workflow(:direct_verifications_grup3) do |workflow|
+  workflow.engine = Decidim::DirectVerifications::Verification::Engine
+end
+Decidim::Verifications.register_workflow(:direct_verifications_grup4) do |workflow|
+  workflow.engine = Decidim::DirectVerifications::Verification::Engine
+end
+Decidim::Verifications.register_workflow(:direct_verifications_grup5) do |workflow|
+  workflow.engine = Decidim::DirectVerifications::Verification::Engine
+end
+Decidim::Verifications.register_workflow(:direct_verifications_grup6) do |workflow|
+  workflow.engine = Decidim::DirectVerifications::Verification::Engine
+end
+Decidim::Verifications.register_workflow(:direct_verifications_grup7) do |workflow|
+  workflow.engine = Decidim::DirectVerifications::Verification::Engine
+end
+Decidim::Verifications.register_workflow(:direct_verifications_grup8) do |workflow|
+  workflow.engine = Decidim::DirectVerifications::Verification::Engine
+end
+Decidim::Verifications.register_workflow(:direct_verifications_grup9) do |workflow|
+  workflow.engine = Decidim::DirectVerifications::Verification::Engine
+end
+
+# We need to tell the plugin to handle this method in addition to the default "Direct verification". Any registered workflow is valid.
+Decidim::DirectVerifications.configure do |config|
+  config.manage_workflows = %w(direct_verifications_grup1 direct_verifications_grup2 direct_verifications_grup3 direct_verifications_grup4 direct_verifications_grup5 direct_verifications_grup6 direct_verifications_grup7 direct_verifications_grup8 direct_verifications_grup9)
+end

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -5,3 +5,34 @@ ca:
         voting_rules:
           threshold_per_proposal:
             description: Per ser validades, les propostes han d'arribar a %{limit} suports
+    authorization_handlers:
+      direct_verifications:
+        name: Cens general
+        explanation: Verificació directa per al cens general
+      direct_verifications_grup1:
+        name: Grup 1
+        explanation: Verificació directa per al cens de Grup 1
+      direct_verifications_grup2:
+        name: Grup 2
+        explanation: Verificació directa per al cens de Grup 2
+      direct_verifications_grup3:
+        name: Grup 3
+        explanation: Verificació directa per al cens de Grup 3
+      direct_verifications_grup4:
+        name: Grup 4
+        explanation: Verificació directa per al cens de Grup 4
+      direct_verifications_grup5:
+        name: Grup 5
+        explanation: Verificació directa per al cens de Grup 5
+      direct_verifications_grup6:
+        name: Grup 6
+        explanation: Verificació directa per al cens de Grup 6
+      direct_verifications_grup7:
+        name: Grup 7
+        explanation: Verificació directa per al cens de Grup 7
+      direct_verifications_grup8:
+        name: Grup 8
+        explanation: Verificació directa per al cens de Grup 8
+      direct_verifications_grup9:
+        name: Grup 9
+        explanation: Verificació directa per al cens de Grup 9

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -5,3 +5,34 @@ es:
         voting_rules:
           threshold_per_proposal:
             description: Para ser validadas, las propuestas deben llegar a %{limit} apoyos
+    authorization_handlers:
+      direct_verifications:
+        name: Censo general
+        explanation: Verificación directa para el censo general
+      direct_verifications_grup1:
+        name: Grupo 1
+        explanation: Verificación directa para el censo de Grupo 1
+      direct_verifications_grup2:
+        name: Grupo 2
+        explanation: Verificación directa para el censo de Grupo 2
+      direct_verifications_grup3:
+        name: Grupo 3
+        explanation: Verificación directa para el censo de Grupo 3
+      direct_verifications_grup4:
+        name: Grupo 4
+        explanation: Verificación directa para el censo de Grupo 4
+      direct_verifications_grup5:
+        name: Grupo 5
+        explanation: Verificación directa para el censo de Grupo 5
+      direct_verifications_grup6:
+        name: Grupo 6
+        explanation: Verificación directa para el censo de Grupo 6
+      direct_verifications_grup7:
+        name: Grupo 7
+        explanation: Verificación directa para el censo de Grupo 7
+      direct_verifications_grup8:
+        name: Grupo 8
+        explanation: Verificación directa para el censo de Grupo 8
+      direct_verifications_grup9:
+        name: Grupo 9
+        explanation: Verificación directa para el censo de Grupo 9


### PR DESCRIPTION
#### :tophat: What? Why?

Add 9 groups to decidim-direct_verifications module configuration.

More information about this module can be found at
- https://github.com/Platoniq/decidim-verifications-direct_verifications

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests