### PR TITLE
Use Redis as cache store

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -67,11 +67,12 @@ Rails.application.configure do
   config.log_tags = [ :request_id ]
 
   # Use a different cache store in production.
-  if ENV["MEMCACHEDCLOUD_SERVERS"].present?
-    config.cache_store = :dalli_store, ENV["MEMCACHEDCLOUD_SERVERS"].split(","), {
-      username: ENV["MEMCACHEDCLOUD_USERNAME"], password: ENV["MEMCACHEDCLOUD_PASSWORD"]
-    }
-  end
+  # if ENV["MEMCACHEDCLOUD_SERVERS"].present?
+  #   config.cache_store = :dalli_store, ENV["MEMCACHEDCLOUD_SERVERS"].split(","), {
+  #     username: ENV["MEMCACHEDCLOUD_USERNAME"], password: ENV["MEMCACHEDCLOUD_PASSWORD"]
+  #   }
+  # end
+  config.cache_store = :redis_cache_store, { url: ENV['REDIS_URL'] }
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   config.active_job.queue_adapter     = :sidekiq


### PR DESCRIPTION
As `term-customizer` performs partial clearings of cache (which is not supported by memcached) Redis seems more suited for `term-customizer`.