### PR TITLE
Upgrade gem `rails_autoscale_agent`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -642,7 +642,7 @@ GEM
       railties (>= 5.0, < 6)
     rails-observers (0.1.5)
       activemodel (>= 4.0)
-    rails_autoscale_agent (0.8.1)
+    rails_autoscale_agent (0.9.1)
     railties (5.2.4.4)
       actionpack (= 5.2.4.4)
       activesupport (= 5.2.4.4)


### PR DESCRIPTION
We're running an outdated `rails_autoscale_agent` gem (v0.8.1).
Upgrade to v0.9.1