### PR TITLE
Update decidim-term_customizer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,7 +193,7 @@ GIT
 
 GIT
   remote: https://github.com/mainio/decidim-module-term_customizer
-  revision: 9540a2ab20b872896e51ea5f97c5ebae3388ca60
+  revision: f0d720710822f1231ea249dd71f978143d38a6c4
   branch: release/0.26-stable
   specs:
     decidim-term_customizer (0.26.0)


### PR DESCRIPTION
Update `decidim-term_customizer` version after the inclusion of the backport that fixes the consultations and initiatives error in the `release/0.26-stable` branch.