### PR TITLE
Remove unused gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,10 +65,7 @@ group :production do
   gem "appsignal"
   gem "aws-sdk-s3", require: false
   gem "dalli"
-  gem "fog-aws"
   gem "lograge"
   gem "platform-api"
-  gem "rails_autoscale_agent"
-  gem "sendgrid-ruby"
   gem "whenever", require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,5 @@ group :production do
   gem "platform-api"
   gem "rails_autoscale_agent"
   gem "sendgrid-ruby"
-  gem "sentry-raven"
   gem "whenever", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -525,24 +525,13 @@ GEM
     file_validators (3.0.0)
       activemodel (>= 3.2)
       mime-types (>= 1.0)
-    fog-aws (3.32.0)
-      base64 (~> 0.2.0)
-      fog-core (~> 2.6)
-      fog-json (~> 1.1)
-      fog-xml (~> 0.1)
     fog-core (2.6.0)
       builder
       excon (~> 1.0)
       formatador (>= 0.2, < 2.0)
       mime-types
-    fog-json (1.2.0)
-      fog-core
-      multi_json (~> 1.10)
     fog-local (0.9.0)
       fog-core (>= 1.27, < 3.0)
-    fog-xml (0.1.5)
-      fog-core
-      nokogiri (>= 1.5.11, < 2.0.0)
     formatador (1.2.3)
       reline
     gemoji (3.0.1)
@@ -862,7 +851,6 @@ GEM
       railties (>= 6.0.0, < 8)
     rails-observers (0.1.5)
       activemodel (>= 4.0)
-    rails_autoscale_agent (0.12.0)
     railties (7.2.3.1)
       actionpack (= 7.2.3.1)
       activesupport (= 7.2.3.1)
@@ -997,7 +985,6 @@ GEM
     rubyXL (3.4.33)
       nokogiri (>= 1.10.8)
       rubyzip (>= 1.3.0)
-    ruby_http_client (3.5.5)
     rubyzip (2.3.2)
     sass-embedded (1.100.0-arm64-darwin)
       google-protobuf (~> 4.31)
@@ -1013,8 +1000,6 @@ GEM
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
     semantic_range (3.1.1)
-    sendgrid-ruby (6.7.0)
-      ruby_http_client (~> 3.4)
     shakapacker (8.3.0)
       activesupport (>= 5.2)
       package_json
@@ -1151,7 +1136,6 @@ DEPENDENCIES
   decidim-term_customizer!
   dotenv-rails
   faker
-  fog-aws
   letter_opener_web (~> 2.0.0)
   listen (~> 3.1)
   lograge
@@ -1160,13 +1144,11 @@ DEPENDENCIES
   platform-api
   puma (>= 5.0.0)
   rails-observers
-  rails_autoscale_agent
   rspec-rails
   rubocop-faker
   ruby-lsp
   ruby-lsp-rails
   ruby-lsp-rspec
-  sendgrid-ruby
   sidekiq
   uglifier
   web-console (~> 4.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1015,8 +1015,6 @@ GEM
     semantic_range (3.1.1)
     sendgrid-ruby (6.7.0)
       ruby_http_client (~> 3.4)
-    sentry-raven (3.1.2)
-      faraday (>= 1.0)
     shakapacker (8.3.0)
       activesupport (>= 5.2)
       package_json
@@ -1169,7 +1167,6 @@ DEPENDENCIES
   ruby-lsp-rails
   ruby-lsp-rspec
   sendgrid-ruby
-  sentry-raven
   sidekiq
   uglifier
   web-console (~> 4.2)

--- a/app/controllers/decidim_controller.rb
+++ b/app/controllers/decidim_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Entry point for Decidim. It will use the `DecidimController` as
 # entry point, but you can change what controller it inherits from
 # so you can customize some methods.

--- a/app/controllers/decidim_controller.rb
+++ b/app/controllers/decidim_controller.rb
@@ -1,17 +1,5 @@
-# frozen_string_literal: true
-
 # Entry point for Decidim. It will use the `DecidimController` as
 # entry point, but you can change what controller it inherits from
 # so you can customize some methods.
 class DecidimController < ApplicationController
-  before_action :set_raven_context
-
-  private
-
-  def set_raven_context
-    return if ENV["SENTRY_ENABLED"].blank?
-
-    Raven.user_context({ id: try(:current_user).try(:id) }.merge(session))
-    Raven.extra_context(params: params.to_unsafe_h, url: request.url)
-  end
 end


### PR DESCRIPTION
The deprecated sentry-raven gem is incompatible with Rails 7.2. Its render_exception override takes 2 arguments while Rails 7.2 calls it with 3, so rendering any exception raises ArgumentError: wrong number of arguments (given 3, expected 2). This masks the real error (and likely interferes with error reporting in general).
We are deleting it as we don't use Sentry anymore.